### PR TITLE
Bugged warps

### DIFF
--- a/TrackingMode/Tracker.cs
+++ b/TrackingMode/Tracker.cs
@@ -277,13 +277,13 @@ namespace AccessibleTiles.TrackingMode {
 
                 Vector2 tile = new(currentX, currentY);
 
-                mod.console.Debug($"{i}) {tile}");
+                //mod.console.Debug($"{i}) {tile}");
                 if (currentX == tileXY.X && currentY == tileXY.Y) {
                     currentX++;
                     continue;
                 }
 
-                mod.console.Debug($"Check Tile: {tile}");
+                //mod.console.Debug($"Check Tile: {tile}");
 
                 if (!mod.IsColliding(tile)) {
 

--- a/TrackingMode/Tracker.cs
+++ b/TrackingMode/Tracker.cs
@@ -55,7 +55,7 @@ namespace AccessibleTiles.TrackingMode {
             TrackCategory("Resources", TrackerUtility.GetResources(mod));
             TrackCategory("Bundles", TrackerUtility.GetBundles());
             TrackCategory("Characters", TrackerUtility.GetCharacters());
-            TrackCategory("Entrances", TrackerUtility.GetEntrances());
+            TrackCategory("Entrances", TrackerUtility.GetEntrances(mod));
             TrackCategory("FarmBuildings", TrackerUtility.GetBuildings());
             TrackCategory("P O I", TrackerUtility.GetPOIs());
 

--- a/TrackingMode/TrackerUtility.cs
+++ b/TrackingMode/TrackerUtility.cs
@@ -442,14 +442,60 @@ namespace AccessibleTiles.TrackingMode {
             GameLocation location = Game1.currentLocation;
 
             SortedList<string, SpecialObject> doors = new();
+            Dictionary<string, int> added_names = new();
+
             foreach (Point point in location.doors.Keys) {
                 string str = location.doors[point];
+
+                if(added_names.ContainsKey(str)) {
+                    added_names[str]++;
+                    str += $" {added_names[str]}";
+                } else {
+                    added_names.Add(str, 1);
+                }
+
                 doors[str] = new SpecialObject(str, new(point.X, point.Y));
             }
 
             foreach (Warp point in location.warps) {
-                if (point.TargetName.ToLower() == "desert") continue;
-                doors[point.TargetName] = new SpecialObject(point.TargetName, new(point.X, point.Y));
+                string str = point.TargetName;
+                if (str.ToLower() == "desert") continue;
+
+                if (added_names.ContainsKey(str)) {
+
+                    //make sure this warp is not directly next to an existing one
+
+                    bool add = true;
+
+                    int number = added_names[str];
+
+                    string name = str;
+                    if(number > 1) {
+                        name += $" {number}";
+                    }
+                    SpecialObject previous_warp = doors[name];
+
+                    for (int i = -5; i < 5; i++) {
+                        if (previous_warp.TileLocation.X == point.X && previous_warp.TileLocation.Y == point.Y + i) {
+                            add = false;
+                        }
+                        if (previous_warp.TileLocation.Y == point.Y && previous_warp.TileLocation.X == point.X + i) {
+                            add = false;
+                        }
+                    }
+
+                    if (add) {
+                        added_names[str]++;
+                        str += $" {added_names[str]}";
+                        doors[str] = new SpecialObject(str, new(point.X, point.Y));
+                    }
+                    
+                } else {
+                    added_names.Add(str, 1);
+                    doors[str] = new SpecialObject(str, new(point.X, point.Y));
+                }
+
+                
             }
 
             return doors;

--- a/TrackingMode/TrackerUtility.cs
+++ b/TrackingMode/TrackerUtility.cs
@@ -437,7 +437,7 @@ namespace AccessibleTiles.TrackingMode {
 
         }
 
-        public static SortedList<string, SpecialObject> GetEntrances() {
+        public static SortedList<string, SpecialObject> GetEntrances(ModEntry mod) {
 
             GameLocation location = Game1.currentLocation;
 
@@ -475,12 +475,18 @@ namespace AccessibleTiles.TrackingMode {
                     }
                     SpecialObject previous_warp = doors[name];
 
+                    if (mod.IsColliding(new(point.X, point.Y))) {
+                        add = false;
+                    }
+
                     for (int i = -5; i < 5; i++) {
-                        if (previous_warp.TileLocation.X == point.X && previous_warp.TileLocation.Y == point.Y + i) {
-                            add = false;
-                        }
-                        if (previous_warp.TileLocation.Y == point.Y && previous_warp.TileLocation.X == point.X + i) {
-                            add = false;
+                        if(add) {
+                            if (previous_warp.TileLocation.X == point.X && previous_warp.TileLocation.Y == point.Y + i) {
+                                add = false;
+                            }
+                            if (previous_warp.TileLocation.Y == point.Y && previous_warp.TileLocation.X == point.X + i) {
+                                add = false;
+                            }
                         }
                     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "AccessibleTiles",
   "Author": "GrumpyCrouton",
-  "Version": "2.2.0",
+  "Version": "2.2.1",
   "Description": "Moved the player based on the tile grid",
   "UniqueID": "GrumpyCrouton.AccessibleTiles",
   "EntryDll": "AccessibleTiles.dll",


### PR DESCRIPTION
Fixes issue where unreachable warp locations were being displayed instead of reachable ones by allowing warps with the same name (appends a number if there are duplicates), and doesn't add any warps that are at a position the player can't walk.